### PR TITLE
Feature add response header processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 /.purs*
 /.psa*
 package-lock.json
-package.json

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ All requests have 4 versions:
 - `postR`: Like `post`, but takes a subset of a `SimpleRequest` as an additional argument (for example if additional headers are needed).
 - `postR_`: Like `post_`, but takes a subset of a `SimpleRequest` as an additional argument.
 
+`POST` requests also have variations that includes the response headers. `(Tuple (Array ResponseHeader) b)` is returned in place of `b`, where `b` is just `unit` in the `_` versions: `postH`, `postH_`, `postRH`, `postRH_`
+
 `get` and `getR` don't have a underscore version.
 
 Requests payload objects must implement an instance of `WriteForeign` and responses payload objects must implement an instance of `ReadForeign`.
@@ -23,7 +25,7 @@ Check [simple-json](https://github.com/justinwoo/purescript-simple-json) documen
 
 ## Requests
 
-`simpleRequest`, `getR`, `postR`, `putR`, `deleteR` and `patchR` (and the
+`simpleRequest`, `getR`, `postR`, `postRH`, `putR`, `deleteR` and `patchR` (and the
 versions ending with an underscore) accept a subset of a `SimpleRequest` as
 an argument. 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "purescript-simple-ajax",
+  "version": "1.0.0",
+  "description": "An opinionated library to work with AJAX and JSON, using [`simple-json`](https://pursuit.purescript.org/packages/purescript-simple-json) and [`variant`](https://pursuit.purescript.org/packages/purescript-variant).",
+  "directories": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dariooddenino/purescript-simple-ajax.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/dariooddenino/purescript-simple-ajax/issues"
+  },
+  "homepage": "https://github.com/dariooddenino/purescript-simple-ajax#readme",
+  "devDependencies": {
+    "express": "^4.16.4",
+    "xhr2": "^0.1.4"
+  }
+}

--- a/test/Main.js
+++ b/test/Main.js
@@ -25,6 +25,11 @@ exports.startServer = function (errback, callback) {
     res.send('TODO');
   });
 
+  app.post('/register', function(req, res) {
+    res.set('Authorization', 'Bearer: fake_token');
+    res.json({result: "Thanks"});
+  });
+
   app.get('/not-json', function(req, res) {
     res.header({'content-type': 'text/plain'});
     res.send('This is not JSON');


### PR DESCRIPTION
Addresses #1 

* I had to add dependencies for express via npm. So this requires `npm i` for tests to work.
* Added a test for a route that includes a header in the response.

I'm very new to using Purescript, so I expect there must be a shorter refactoring to get these routes to work. Feel free to just not merge this or I would greatly appreciate some tips on how you think that could be done.