### PR TITLE
Update affjax to v11.0.0 (breaking changes)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "purescript-prelude": "^4.1.1",
-    "purescript-affjax": "^10.1.0",
+    "purescript-affjax": "^11.0.0",
     "purescript-simple-json": "^7.0.0"
   },
   "devDependencies": {

--- a/src/Simple/Ajax.purs
+++ b/src/Simple/Ajax.purs
@@ -24,6 +24,7 @@ import Data.Either (Either(..))
 import Data.HTTP.Method (CustomMethod, Method(..))
 import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType(..))
+import Data.Time.Duration (Milliseconds)
 import Data.Tuple (Tuple(..), snd)
 import Data.Variant (expand, inj)
 import Effect.Aff (Aff)
@@ -93,6 +94,7 @@ type RequestRow a = ( method          :: Either Method CustomMethod
                     , password        :: Maybe String
                     , withCredentials :: Boolean
                     , responseFormat  :: ResponseFormat a
+                    , timeout         :: Maybe Milliseconds
                     )
 
 type SimpleRequestRow = ( headers         :: Array RequestHeader


### PR DESCRIPTION
When updating `affjax` to `v11.0.0` in `purescript/package-sets`, I noticed this will break `purescript-simple-ajax`.

https://github.com/purescript/package-sets/pull/724/checks?check_run_id=1239307442

With this PR the repo should work with updated version and breaking change (https://github.com/purescript-contrib/purescript-affjax/pull/151)

